### PR TITLE
Fix license lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About metis
 
 Home: http://glaros.dtc.umn.edu/gkhome/metis/metis/overview
 
-Package license: Apache License 2.0
+Package license: Apache 2.0
 
 Feedstock license: BSD 3-Clause
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ conda search metis --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
 
 about:
   home: http://glaros.dtc.umn.edu/gkhome/metis/metis/overview
-  license: Apache License 2.0
+  license: Apache 2.0
   license_file: LICENSE.txt
   summary: 'METIS - Serial Graph Partitioning and Fill-reducing Matrix Ordering'
   description: |


### PR DESCRIPTION
Removes the word "License" from the `license` metadata to fix the lint issue.

cc @basnijholt