### PR TITLE
Use stricter run_exports and fix version in headers for 5.1.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,11 +16,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
 # instead of `project(METIS)`.
 
 build:
-  number: 0
+  number: 1
   binary_relocation: true
   ignore_run_exports:        # Cf comment above
     - libstdcxx-ng           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
     patches:
       - patches/0001.patch
       - patches/0002.patch
+      - patches/0003-fix-version-number.patch
 
   - url: https://github.com/KarypisLab/GKlib/archive/3eabb216ac97e11ce7e7a9b90f4c90778d9e7c18.zip
     sha256: e75693a69957445171843a767430db7270de57fa431a415cc3f8e9ed472700e3
@@ -32,7 +33,7 @@ build:
     - libstdcxx-ng           # [linux]
     - libcxx                 # [osx]
   run_exports:
-    - {{ pin_subpackage('metis', max_pin='x.x') }}
+    - {{ pin_subpackage('metis', max_pin='x.x.x') }}
   skip: true  # [win or ppc64le]
 
 requirements:

--- a/recipe/patches/0003-fix-version-number.patch
+++ b/recipe/patches/0003-fix-version-number.patch
@@ -1,0 +1,22 @@
+From 3adf9c89a067203ba380b6687f5604407ddbbb4a Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Tue, 29 Aug 2023 10:39:34 +0200
+Subject: [PATCH] Update metis.h
+
+---
+ include/metis.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/metis.h b/include/metis.h
+index 5000d1b..7b15597 100644
+--- a/include/metis.h
++++ b/include/metis.h
+@@ -157,7 +157,7 @@ typedef __int64 int64_t;
+ /* Metis's version number */
+ #define METIS_VER_MAJOR         5
+ #define METIS_VER_MINOR         1
+-#define METIS_VER_SUBMINOR      0
++#define METIS_VER_SUBMINOR      1
+ 
+ /* The maximum length of the options[] array */
+ #define METIS_NOPTIONS          40


### PR DESCRIPTION
Fix https://github.com/conda-forge/metis-feedstock/issues/37 .

As it emerged in https://github.com/KarypisLab/METIS/issues/71#issuecomment-1696082046, METIS has breaking change in patch releases (in particular between 5.1.0 and 5.1.1), so for the future is better to use a stricter run_exports. 

@conda-forge/metis if you create a v5.1.0 branch, I can do a similar fix also for 5.1.0 builds, so that packages that are pinned to 5.1.0 and that are not compatible with 5.1.1 can also get the correct run_exports.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
