### PR TITLE
Add v5.1.0 to abi_migration_branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,8 @@
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
+bot:
+  abi_migration_branches: 
+  - "v5.1.0"
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 test_on_native_only: true
 github:


### PR DESCRIPTION
As this is the version pinned by conda-forge, see:
* https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5396
* https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5397

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

